### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/go-feed/security/code-scanning/1](https://github.com/RumenDamyanov/go-feed/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, as the steps only need to check out code and upload coverage (which does not require repository write access). No steps require write access to issues, pull requests, or other resources. Therefore, add:

```yaml
permissions:
  contents: read
```

immediately after the `name: CI` line (line 1), before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
